### PR TITLE
Rebuild DeckGL globe and overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,75 @@
 import DeckGlobe from '@/dfl/globe/DeckGlobe';
 import { BASEMAPS, useBasemapStore } from '@/dfl/state/useUiStore';
+import type { BasemapId } from '@/dfl/state/useUiStore';
+import type {
+  PointerEvent,
+  TouchEvent,
+  WheelEvent
+} from 'react';
+
+const blockPointer = (event: PointerEvent<HTMLDivElement>) => {
+  event.stopPropagation();
+};
+
+const blockTouch = (event: TouchEvent<HTMLDivElement>) => {
+  if (event.cancelable) {
+    event.preventDefault();
+  }
+  event.stopPropagation();
+};
+
+const blockWheel = (event: WheelEvent<HTMLDivElement>) => {
+  if (event.cancelable) {
+    event.preventDefault();
+  }
+  event.stopPropagation();
+};
 
 export default function App() {
   return (
-    <div className="h-screen w-screen relative">
+    <div className="relative h-screen w-screen overflow-hidden bg-black text-white">
       <DeckGlobe />
+      <UiOverlay />
+    </div>
+  );
+}
 
-      {/* ↑ UI overlay sits above the globe */}
-      <div
-        className="absolute top-4 left-4 z-20 pointer-events-auto space-y-2
-                   rounded-xl border border-white/10 bg-white/10 p-3 text-sm backdrop-blur"
-        style={{ cursor: 'default' }}
-      >
-        <div className="font-semibold">Drone Globe (deck.gl)</div>
-        <div className="text-white/70">Drag to rotate • Scroll to zoom • Shift+drag to pan</div>
-        <BasemapSelect />
+function UiOverlay() {
+  return (
+    <>
+      <div className="pointer-events-none absolute inset-0 flex flex-col">
+        <div className="pointer-events-auto p-6">
+          <ControlPanel />
+        </div>
+        <div className="pointer-events-auto mt-auto p-4">
+          <Attribution />
+        </div>
       </div>
+    </>
+  );
+}
 
-      {/* Attribution footer above globe too */}
-      <div className="absolute bottom-2 left-2 z-20 pointer-events-auto">
-        <Attribution />
+function ControlPanel() {
+  return (
+    <div
+      className="max-w-xs rounded-2xl border border-white/15 bg-white/10 p-4 backdrop-blur"
+      onPointerDownCapture={blockPointer}
+      onPointerMoveCapture={blockPointer}
+      onPointerUpCapture={blockPointer}
+      onTouchStartCapture={blockTouch}
+      onTouchMoveCapture={blockTouch}
+      onTouchEndCapture={blockTouch}
+      onWheelCapture={blockWheel}
+    >
+      <div className="space-y-3">
+        <header className="space-y-1">
+          <h1 className="text-lg font-semibold text-white">Drone Flight Lab</h1>
+          <p className="text-xs text-white/70">
+            Explore the interactive globe, drag to rotate, scroll or pinch to zoom, and shift-drag to
+            pan.
+          </p>
+        </header>
+        <BasemapSelect />
       </div>
     </div>
   );
@@ -27,17 +77,23 @@ export default function App() {
 
 function BasemapSelect() {
   const { id, setId } = useBasemapStore();
+
   return (
-    <label className="flex items-center gap-2">
-      <span>Basemap:</span>
+    <label className="flex flex-col gap-2 text-sm">
+      <span className="font-medium text-white/80">Basemap</span>
       <select
-        className="bg-black/40 border border-white/20 rounded px-2 py-1"
+        className="rounded-lg border border-white/20 bg-black/40 px-3 py-2 text-white shadow-inner"
         value={id}
-        onChange={(e) => setId(e.target.value as any)}
+        onChange={(event) => setId(event.target.value as BasemapId)}
+        onPointerDownCapture={blockPointer}
+        onPointerUpCapture={blockPointer}
+        onTouchStartCapture={blockTouch}
+        onTouchEndCapture={blockTouch}
+        onWheelCapture={blockWheel}
       >
-        {BASEMAPS.map((b) => (
-          <option key={b.id} value={b.id}>
-            {b.name}
+        {BASEMAPS.map((basemap) => (
+          <option key={basemap.id} value={basemap.id} className="bg-slate-900 text-white">
+            {basemap.name}
           </option>
         ))}
       </select>
@@ -47,10 +103,11 @@ function BasemapSelect() {
 
 function Attribution() {
   const { id } = useBasemapStore();
-  const meta = BASEMAPS.find((b) => b.id === id);
+  const basemap = BASEMAPS.find((candidate) => candidate.id === id) ?? BASEMAPS[0];
+
   return (
-    <div className="rounded bg-black/40 px-2 py-1 text-[11px] text-white/70">
-      {meta?.attribution}
+    <div className="w-fit rounded-full border border-white/10 bg-black/60 px-3 py-1 text-[11px] text-white/70">
+      {basemap.attribution}
     </div>
   );
 }

--- a/src/dfl/globe/DeckGlobe.tsx
+++ b/src/dfl/globe/DeckGlobe.tsx
@@ -1,94 +1,125 @@
+import { useCallback, useMemo } from 'react';
 import { DeckGL } from '@deck.gl/react';
-import * as DeckCore from '@deck.gl/core';
-import { ScatterplotLayer, BitmapLayer } from '@deck.gl/layers';
+import { BitmapLayer, ScatterplotLayer } from '@deck.gl/layers';
 import { TileLayer } from '@deck.gl/geo-layers';
-import { useMemo, useRef, useCallback } from 'react';
+import * as DeckCore from '@deck.gl/core';
 import { useGlobeStore } from '@/dfl/state/useGlobeStore';
 import { BASEMAPS, useBasemapStore } from '@/dfl/state/useUiStore';
 
-const GlobeViewCtor =
-  (DeckCore as any).GlobeView ?? (DeckCore as any)._GlobeView ?? DeckCore.MapView;
+type ViewState = {
+  longitude: number;
+  latitude: number;
+  zoom: number;
+  pitch: number;
+  bearing: number;
+};
 
-function clampZoom(v: any, min = 0.2, max = 5) {
-  return { ...v, zoom: Math.max(min, Math.min(max, v.zoom ?? 0)) };
-}
+type DroneSite = { name: string; position: [number, number, number?] };
+
+const deckCoreAny = DeckCore as unknown as Record<string, unknown>;
+const GlobeViewCtor =
+  (deckCoreAny['GlobeView'] as typeof DeckCore.MapView | undefined) ??
+  (deckCoreAny['_GlobeView'] as typeof DeckCore.MapView | undefined) ??
+  DeckCore.MapView;
+
+const DRONE_SITES: DroneSite[] = [
+  { name: 'San Francisco, USA', position: [-122.389, 37.615, 1500] },
+  { name: 'Paris, France', position: [2.55, 49.0097, 1200] },
+  { name: 'Tokyo, Japan', position: [139.781, 35.549, 900] },
+  { name: 'Sydney, Australia', position: [151.1772, -33.9461, 600] }
+];
+
+const clampViewState = (state: ViewState): ViewState => ({
+  ...state,
+  zoom: Math.max(0.2, Math.min(5, state.zoom))
+});
 
 export default function DeckGlobe() {
-  const viewState = useGlobeStore((s) => s.viewState);
-  const setViewState = useGlobeStore((s) => s.setViewState);
-  const basemapId = useBasemapStore((s) => s.id);
-  const basemap = BASEMAPS.find((b) => b.id === basemapId) ?? BASEMAPS[0];
+  const viewState = useGlobeStore((state) => state.viewState);
+  const setViewState = useGlobeStore((state) => state.setViewState);
+  const basemapId = useBasemapStore((state) => state.id);
 
-  const onWheelCapture = useCallback((e: React.WheelEvent) => {
-    if (e.ctrlKey) { e.preventDefault(); e.stopPropagation(); }
-  }, []);
+  const basemap = useMemo(
+    () => BASEMAPS.find((candidate) => candidate.id === basemapId) ?? BASEMAPS[0],
+    [basemapId]
+  );
 
-  const base = useMemo(
+  const basemapLayer = useMemo(
     () =>
       new TileLayer({
-        id: `base-tiles-${basemap.id}`,
+        id: `basemap-${basemap.id}`,
         data: basemap.url,
         minZoom: 0,
         maxZoom: 5,
         tileSize: 256,
+        pickable: false,
         renderSubLayers: (props) => {
-          const bbox = (props as any).bbox ?? (props as any).tile?.bbox;
-          if (!bbox) return null;
-          const { west, south, east, north } = bbox;
-          return new BitmapLayer({ id: `bitmap-${(props as any).tile?.id ?? Math.random()}` } as any, {
-            data: null,
-            bounds: [west, south, east, north],
-            image: (props as any).data
+          const tile = (props as any).tile;
+          const bounds = tile?.bbox ?? (props as any).bbox;
+          if (!bounds) {
+            return null;
+          }
+          const { west, south, east, north } = bounds;
+          return new BitmapLayer(props, {
+            id: `${props.id}-bitmap`,
+            image: (props as any).data,
+            bounds: [west, south, east, north]
           });
         }
       }),
     [basemap]
   );
 
-  const drones = useMemo(
+  const droneLayer = useMemo(
     () =>
-      new ScatterplotLayer({
-        id: 'drones',
-        data: [
-          { position: [-122.389, 37.615, 1500] },
-          { position: [2.55, 49.0097, 1200] },
-          { position: [139.781, 35.549, 900] }
-        ],
-        getPosition: (d) => d.position,
-        getRadius: 30000,
+      new ScatterplotLayer<DroneSite>({
+        id: 'drone-sites',
+        data: DRONE_SITES,
+        getPosition: (site) => site.position,
+        getRadius: 40000,
         radiusUnits: 'meters',
+        getFillColor: [255, 140, 0, 220],
+        getLineColor: [0, 0, 0, 200],
+        lineWidthUnits: 'pixels',
+        getLineWidth: 2,
+        stroked: true,
         pickable: true
       }),
     []
   );
 
+  const handleViewStateChange = useCallback(
+    ({ viewState: next }: { viewState: ViewState }) => {
+      setViewState(clampViewState(next));
+    },
+    [setViewState]
+  );
+
+  const getTooltip = useCallback((info: { object?: DroneSite | null }) => {
+    if (!info.object) {
+      return null;
+    }
+    return { text: info.object.name };
+  }, []);
+
   return (
-    <div
-      onWheelCapture={onWheelCapture}
-      style=
-            {{
-              position: 'absolute',
-              inset: 0,
-              zIndex: 0,              // 👈 keep globe underneath overlays
-              touchAction: 'none',
-              overscrollBehavior: 'none'
-            }}
-    >
+    <div className="absolute inset-0">
       <DeckGL
         views={new (GlobeViewCtor as any)()}
-        viewState={viewState}
-        onViewStateChange={({ viewState }: { viewState: any }) => setViewState(clampZoom(viewState))}
         controller={{
           dragPan: true,
           dragRotate: true,
-          inertia: 200,
           scrollZoom: { speed: 0.005, smooth: true },
-          doubleClickZoom: false,
-          touchZoomRotate: true
+          touchZoom: true,
+          touchRotate: true,
+          doubleClickZoom: false
         }}
-        layers={[base, drones]}
-        style={{ position: 'absolute', inset: 0, zIndex: 0 }} // 👈
-        />
+        viewState={viewState}
+        onViewStateChange={handleViewStateChange}
+        layers={[basemapLayer, droneLayer]}
+        getTooltip={getTooltip as any}
+        style={{ position: 'absolute', inset: 0 }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the app shell with a fresh overlay that blocks pointer/touch/wheel propagation while exposing the basemap selector and attribution
- rebuild the DeckGL globe integration with memoized tile and drone layers plus zoom clamping and tooltip support
- dynamically resolve the GlobeView constructor so the view initializes without relying on deprecated exports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0adfeea188324bc15607ae74b0a43